### PR TITLE
Python 3 support: use general fixes and six for 2 and 3 support

### DIFF
--- a/mirtop/gff/body.py
+++ b/mirtop/gff/body.py
@@ -46,14 +46,14 @@ def create(reads, database, sample, args):
     if args.add_extra:
         precursors = args.precursors
         matures = args.matures
-    for r, read in reads.iteritems():
+    for r, read in list(reads.items()):
         hits = set()
-        [hits.add(mature.mirna) for mature in read.precursors.values()
+        [hits.add(mature.mirna) for mature in list(read.precursors.values())
             if mature.mirna]
         hits = len(hits)
         if len(read.precursors) > 0:
             n_reads += 1
-        for p, iso in read.precursors.iteritems():
+        for p, iso in list(read.precursors.items()):
             if not iso.mirna:
                 filter_precursor += 1
                 continue
@@ -162,8 +162,8 @@ def read_variant(attrb, sep=" "):
             gff_dict[item_pair[0].strip()] = int(item_pair[1].strip())
         else:
             gff_dict[item_pair[0].strip()] = True
-    logger.debug("Keys found: %s" % gff_dict.keys())
-    logger.debug("Values found: %s" % gff_dict.values())
+    logger.debug("Keys found: %s" % list(gff_dict.keys()))
+    logger.debug("Values found: %s" % list(gff_dict.values()))
     return gff_dict
 
 

--- a/mirtop/gff/compare.py
+++ b/mirtop/gff/compare.py
@@ -36,7 +36,7 @@ def compare(args):
         fn_out = os.path.join(args.out, "summary.txt")
         with open(fn_out, 'w') as outh:
             for fn in result:
-                print("sample\tidu\tseq\ttag\tsame_mirna\t%s" % "\t".join(result[fn][0][3].keys()), file=outh)
+                print("sample\tidu\tseq\ttag\tsame_mirna\t%s" % "\t".join(list(result[fn][0][3].keys())), file=outh)
                 for line in result[fn]:
                     read = read_id(line[0])
                     acc = "\t".join([line[3][v] for v in line[3]])
@@ -132,6 +132,6 @@ def _accuracy(target, reference):
             accuracy[t] = "TP" if t in target else "FN"
         else:
             accuracy[t] = "TN" if t not in target else "FP"
-    logger.debug("COMPARE::ACCURACY::%s" % accuracy.keys())
-    logger.debug("COMPARE::ACCURACY::%s" % accuracy.values())
+    logger.debug("COMPARE::ACCURACY::%s" % list(accuracy.keys()))
+    logger.debug("COMPARE::ACCURACY::%s" % list(accuracy.values()))
     return accuracy

--- a/mirtop/gff/convert.py
+++ b/mirtop/gff/convert.py
@@ -123,4 +123,4 @@ def _expand(variant, nts=False):
     else:
         snp = sum(snp_var)
         list_variant.append(snp)
-    return map(str, list_variant)
+    return list(map(str, list_variant))

--- a/mirtop/gff/merge.py
+++ b/mirtop/gff/merge.py
@@ -54,7 +54,7 @@ def _format_samples_counts(samples, expression):
     else:
         samples = [samples]
         expression = [expression]
-    return dict(zip(samples, expression))
+    return dict(list(zip(samples, expression)))
 
 
 def _fix(line, expression):

--- a/mirtop/gff/stats.py
+++ b/mirtop/gff/stats.py
@@ -84,7 +84,7 @@ def _classify(srna_type, attr, samples):
     # iso_5p, iso_3p, iso_add ...
     # FILTER :: exact/isomiR_type
     lines = []
-    counts = dict(zip(samples, attr['Expression'].split(",")))
+    counts = dict(list(zip(samples, attr['Expression'].split(","))))
     for s in counts:
         if int(counts[s]) > 0:
             lines.append([srna_type, s, counts[s]])

--- a/mirtop/gff/validator.py
+++ b/mirtop/gff/validator.py
@@ -80,7 +80,7 @@ def _check_line(line, num, num_samples):
     # Check attribute-expression
 
     expression = fields['attrb']['Expression'].strip().split(",")
-    expression = filter(None, expression)
+    expression = [_f for _f in expression if _f]
     if len(expression) != num_samples:
         logger.error('INCORRECT number of EXPRESSION VALUES \
         in line %s' % (num))

--- a/mirtop/importer/srnabench.py
+++ b/mirtop/importer/srnabench.py
@@ -152,7 +152,7 @@ def _read_iso(fn):
                 label = [cols[3].split("$")[0]]
             if len(mirnas) != len(label):
                 label = label * (len(mirnas) - len(label))
-            anno = dict(zip(mirnas, label))
+            anno = dict(list(zip(mirnas, label)))
             logger.debug("TRANSLATE::%s with %s" % (mirnas, label))
             for m in anno:
                 iso[(cols[0], m)] = _translate(anno[m], cols[4])

--- a/mirtop/install.py
+++ b/mirtop/install.py
@@ -1,7 +1,7 @@
 """
 Some commands to install common databases like mirbase and some human/mouse annotation
 """
-
+from __future__ import print_function
 import os.path as op
 import subprocess
 

--- a/mirtop/libs/do.py
+++ b/mirtop/libs/do.py
@@ -5,6 +5,9 @@ import os
 import subprocess
 import logging
 
+import six
+
+
 logger = logging.getLogger("run")
 
 
@@ -13,7 +16,7 @@ def run(cmd, data=None, checks=None, region=None, log_error=True,
     """Run the provided command, logging details and checking for errors.
     """
     try:
-        logger.debug(" ".join(str(x) for x in cmd) if not isinstance(cmd, basestring) else cmd)
+        logger.debug(" ".join(str(x) for x in cmd) if not isinstance(cmd, six.string_types) else cmd)
         _do_run(cmd, checks, log_stdout)
     except:
         if log_error:
@@ -41,7 +44,7 @@ def _normalize_cmd_args(cmd):
     Piped commands set pipefail and require use of bash to help with debugging
     intermediate errors.
     """
-    if isinstance(cmd, basestring):
+    if isinstance(cmd, six.string_types):
         # check for standard or anonymous named pipes
         if cmd.find(" | ") > 0 or cmd.find(">(") or cmd.find("<("):
             return "set -o pipefail; " + cmd, True, find_bash()
@@ -71,7 +74,7 @@ def _do_run(cmd, checks, log_stdout=False):
             for line in s.stdout:
                 debug_stdout.append(line)
             if exitcode is not None and exitcode != 0:
-                error_msg = " ".join(cmd) if not isinstance(cmd, basestring) else cmd
+                error_msg = " ".join(cmd) if not isinstance(cmd, six.string_types) else cmd
                 error_msg += "\n"
                 error_msg += "".join(debug_stdout)
                 s.communicate()

--- a/mirtop/libs/parse.py
+++ b/mirtop/libs/parse.py
@@ -24,7 +24,7 @@ def parse_cl(in_args):
         sub_cmds[in_args[0]](subparsers)
         sub_cmd = in_args[0]
     else:
-        print("use %s" % sub_cmds.keys())
+        print("use %s" % list(sub_cmds.keys()))
         sys.exit(0)
     args = parser.parse_args()
     if "files" in args:

--- a/mirtop/mirna/realign.py
+++ b/mirtop/mirna/realign.py
@@ -439,7 +439,7 @@ def align_from_variants(sequence, mature, variants):
     snps = []
     k = [v.split(":")[0] for v in variants.split(",") if v.find(":") > -1]
     v = [int(v.split(":")[1]) for v in variants.split(",") if v.find(":") > -1]
-    var_dict = dict(zip(k, v))
+    var_dict = dict(list(zip(k, v)))
     logger.debug("realign::align_from_variants::sequence %s" % sequence)
     logger.debug("realign::align_from_variants::mature %s" % mature)
     logger.debug("realign::align_from_variants::variants %s" % variants)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 biopython
 pyyaml
 pybedtools
+six


### PR DESCRIPTION
This makes the code base compatible with Python 3 in a first step
towards moving bcbio and dependencies. It uses six and general
changes to make it both 2 and 3 compatible and tests pass for me on
both. The changes are:

- Add six as a dependency.
- Use six for generally specifying basestring/str.
- Avoid changes in iterators/lists from 2/3 by enumerating with list.
- A few cleaned print statements