### PR TITLE
Python 3 support: use six for encoding and basestring

### DIFF
--- a/mirtop/exporter/vcf.py
+++ b/mirtop/exporter/vcf.py
@@ -4,6 +4,8 @@ import datetime
 import sys
 import os.path as op
 
+import six
+
 from mirtop.mirna.fasta import read_precursor
 from mirtop.mirna.mapper import read_gtf_to_precursor, read_gtf_to_mirna
 from mirtop.gff.body import read_gff_line
@@ -124,12 +126,14 @@ def create_vcf(mirgff3, precursor, gtf, vcffile):
     """
     #Check if the input files exist:
     try:
-        gff3_file = open(mirgff3, "r")
+        gff3_file = open(mirgff3, "r", encoding="utf-8") if six.PY3 else open(mirgff3, "r")
     except IOError:
         print ("Can't read the file", end=mirgff3)
         sys.exit()
     with gff3_file:
-        data = gff3_file.read().decode("utf-8-sig").encode("utf-8")
+        data = gff3_file.read()
+        if six.PY2:
+            data = data.decode("utf-8-sig").encode("utf-8")
 
     gff3_data = data.split("\n")
     vcf_file = open(vcffile, "w")

--- a/mirtop/libs/do.py
+++ b/mirtop/libs/do.py
@@ -5,6 +5,9 @@ import os
 import subprocess
 import logging
 
+import six
+
+
 logger = logging.getLogger("run")
 
 
@@ -13,7 +16,7 @@ def run(cmd, data=None, checks=None, region=None, log_error=True,
     """Run the provided command, logging details and checking for errors.
     """
     try:
-        logger.debug(" ".join(str(x) for x in cmd) if not isinstance(cmd, basestring) else cmd)
+        logger.debug(" ".join(str(x) for x in cmd) if not isinstance(cmd, six.string_types) else cmd)
         _do_run(cmd, checks, log_stdout)
     except:
         if log_error:
@@ -41,7 +44,7 @@ def _normalize_cmd_args(cmd):
     Piped commands set pipefail and require use of bash to help with debugging
     intermediate errors.
     """
-    if isinstance(cmd, basestring):
+    if isinstance(cmd, six.string_types):
         # check for standard or anonymous named pipes
         if cmd.find(" | ") > 0 or cmd.find(">(") or cmd.find("<("):
             return "set -o pipefail; " + cmd, True, find_bash()
@@ -71,7 +74,7 @@ def _do_run(cmd, checks, log_stdout=False):
             for line in s.stdout:
                 debug_stdout.append(line)
             if exitcode is not None and exitcode != 0:
-                error_msg = " ".join(cmd) if not isinstance(cmd, basestring) else cmd
+                error_msg = " ".join(cmd) if not isinstance(cmd, six.string_types) else cmd
                 error_msg += "\n"
                 error_msg += "".join(debug_stdout)
                 s.communicate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 biopython
 pyyaml
 pybedtools
+six


### PR DESCRIPTION
Works from dev branch, fixing two remaining items preventing tests
from passing on Python 3 using six:

- UTF encoding when working with GFF input files
- basestring comparisons