### PR TITLE
Quote bam files before passing to samtools

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+0.4.26
+
+*  Support spaces and special characters in bam files
+
 0.4.25
 
 * [fix outliers samples](https://github.com/nf-core/smrnaseq/issues/137). When there is no identification of reference sequences or isomirs, the multiqc module will fails because it won't find the expected keys. Adding 0 when is the case.

--- a/mirtop/bam/bam.py
+++ b/mirtop/bam/bam.py
@@ -6,6 +6,7 @@ import os.path as op
 import os
 import pysam
 from collections import defaultdict
+from shlex import quote
 
 import pybedtools
 
@@ -321,7 +322,7 @@ def _sam_to_bam(bam_fn):
     if not bam_fn.endswith("bam"):
         bam_out = "%s.bam" % os.path.splitext(bam_fn)[0]
         cmd = "samtools view -Sbh {bam_fn} -o {bam_out}"
-        do.run(cmd.format(**locals()))
+        do.run(cmd.format(bam_fn=quote(bam_fn), bam_out=quote(bam_out)))
         return bam_out
     return bam_fn
 
@@ -330,7 +331,7 @@ def _bam_sort(bam_fn):
     bam_sort_by_n = op.splitext(bam_fn)[0] + "_sort.bam"
     if not file_exists(bam_sort_by_n):
         do.run(("samtools sort -n -o {bam_sort_by_n} {bam_fn}").format(
-            **locals()))
+            bam_sort_by_n=quote(bam_sort_by_n), bam_fn=quote(bam_fn)))
     return bam_sort_by_n
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '0.4.25'
+version = '0.4.26'
 
 url = 'http://github.com/mirtop/mirtop'
 


### PR DESCRIPTION
This adds support for e.g. spaces in bam filenames.